### PR TITLE
Pull latest support for jmalloc 5.3, heroku stack 22

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,3 +55,4 @@ all:
 	$(MAKE) heroku-18 heroku-20 VERSION=5.1.0
 	$(MAKE) heroku-18 heroku-20 VERSION=5.2.0
 	$(MAKE) heroku-18 heroku-20 VERSION=5.2.1
+	$(MAKE) heroku-18 heroku-20 VERSION=5.3.0

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-default: heroku-18 heroku-20
+default: heroku-18 heroku-20 heroku-22
 
 VERSION := 5.2.0
 ROOT_DIR := $(shell dirname $(abspath $(lastword $(MAKEFILE_LIST))))
@@ -42,17 +42,22 @@ heroku-20: src/jemalloc-$(VERSION).tar.bz2 docker\:pull
 	docker run --rm -it --volume="$(ROOT_DIR):/wrk" \
 		heroku/heroku:20-build /wrk/build.sh $(VERSION) heroku-20
 
+# Build for heroku-22 stack
+heroku-22: src/jemalloc-$(VERSION).tar.bz2 docker\:pull
+	docker run --rm -it --volume="$(ROOT_DIR):/wrk" \
+		heroku/heroku:22-build /wrk/build.sh $(VERSION) heroku-22
+
 # Build recent releases for all supported stacks
 all:
-	$(MAKE) heroku-18 heroku-20 VERSION=3.6.0
-	$(MAKE) heroku-18 heroku-20 VERSION=4.0.4
-	$(MAKE) heroku-18 heroku-20 VERSION=4.1.1
-	$(MAKE) heroku-18 heroku-20 VERSION=4.2.1
-	$(MAKE) heroku-18 heroku-20 VERSION=4.3.1
-	$(MAKE) heroku-18 heroku-20 VERSION=4.4.0
-	$(MAKE) heroku-18 heroku-20 VERSION=4.5.0
-	$(MAKE) heroku-18 heroku-20 VERSION=5.0.1
-	$(MAKE) heroku-18 heroku-20 VERSION=5.1.0
-	$(MAKE) heroku-18 heroku-20 VERSION=5.2.0
-	$(MAKE) heroku-18 heroku-20 VERSION=5.2.1
-	$(MAKE) heroku-18 heroku-20 VERSION=5.3.0
+	$(MAKE) heroku-18 heroku-20 heroku-22 VERSION=3.6.0
+	$(MAKE) heroku-18 heroku-20 heroku-22 VERSION=4.0.4
+	$(MAKE) heroku-18 heroku-20 heroku-22 VERSION=4.1.1
+	$(MAKE) heroku-18 heroku-20 heroku-22 VERSION=4.2.1
+	$(MAKE) heroku-18 heroku-20 heroku-22 VERSION=4.3.1
+	$(MAKE) heroku-18 heroku-20 heroku-22 VERSION=4.4.0
+	$(MAKE) heroku-18 heroku-20 heroku-22 VERSION=4.5.0
+	$(MAKE) heroku-18 heroku-20 heroku-22 VERSION=5.0.1
+	$(MAKE) heroku-18 heroku-20 heroku-22 VERSION=5.1.0
+	$(MAKE) heroku-18 heroku-20 heroku-22 VERSION=5.2.0
+	$(MAKE) heroku-18 heroku-20 heroku-22 VERSION=5.2.1
+	$(MAKE) heroku-18 heroku-20 heroku-22 VERSION=5.3.0

--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ heroku config:set JEMALLOC_VERSION=3.6.0
 | [5.1.0](https://github.com/jemalloc/jemalloc/releases/tag/5.1.0) | 2018-05-08 |
 | [5.2.0](https://github.com/jemalloc/jemalloc/releases/tag/5.2.0) | 2019-04-02 |
 | [5.2.1](https://github.com/jemalloc/jemalloc/releases/tag/5.2.1) | 2019-08-05 |
+| [5.3.0](https://github.com/jemalloc/jemalloc/releases/tag/5.3.0) | 2022-05-06 |
 
 The complete and most up to date list of supported versions and stacks is
 available on the [releases page.](https://github.com/gaffneyc/heroku-buildpack-jemalloc/releases)


### PR DESCRIPTION
- Doesn't upgrade the stack yet, we do that within the `zipline-app` repo (app.json for review apps) and via the GUI (for everything else).
- Summary of changes to jemalloc 5.3 by [phoronix](https://www.phoronix.com/news/Jemalloc-5.3-Released). More detail in the [official release notes](https://github.com/jemalloc/jemalloc/releases).